### PR TITLE
fix phd handbook links

### DIFF
--- a/_includes/guide.html
+++ b/_includes/guide.html
@@ -9,7 +9,7 @@
         </div>
         <div class="row text-center">
             <div class="col-md-6">
-                <a class="hover-secondary" href="http://www-saclay.cea.fr/actif/Guide_du_Doctorant.pdf" target="_blank">
+                <a class="hover-secondary" href="https://collab-intranet-psac.intra.cea.fr/assoc/_layouts/15/download.aspx?sourceUrl=%2Fassoc%2FDocuments%20partages%2FACTIF%2DGuide%2Ddu%2DDoctorant%2Epdf" target="_blank">
                     <span class="fa-stack fa-4x">
                         <i class="fa fa-circle fa-stack-2x"></i>
                         <i class="fa fa-file fa-stack-1x fa-inverse"></i>
@@ -18,7 +18,7 @@
                 <h4 class="service-heading">Version Française</h4>
             </div>
             <div class="col-md-6">
-                <a class="hover-secondary" href="http://www-saclay.cea.fr/actif/PHD_handbook.pdf" target="_blank">
+                <a class="hover-secondary" href="https://collab-intranet-psac.intra.cea.fr/assoc/_layouts/15/download.aspx?SourceUrl=%2Fassoc%2FDocuments%20partages%2FACTIF%2DPHD%2Dhandbook%2Epdf" target="_blank">
                     <span class="fa-stack fa-4x">
                         <i class="fa fa-circle fa-stack-2x"></i>
                         <i class="fa fa-file fa-stack-1x fa-inverse"></i>


### PR DESCRIPTION
The migration to the new Paris-Saclay intranet broke the links to the PhD handbook.